### PR TITLE
Fix for Issue35: -tpm argument

### DIFF
--- a/cmd/txt-suite/cmd.go
+++ b/cmd/txt-suite/cmd.go
@@ -15,6 +15,7 @@ var keeprunning = flag.Bool("i", false, "Errors will not stop the testing. Tests
 var help = flag.Bool("h", false, "Shows help")
 var listtests = flag.Bool("l", false, "Lists all test")
 var version = flag.Bool("v", false, "Shows Version, copyright info and license")
+var tpmdev = flag.String("tpm", "", "Select TPM-Path. e.g.: -tpm=/dev/tpmX, with X as number of the TPM module")
 
 func flagUsed() bool {
 	return testno != nil

--- a/cmd/txt-suite/main.go
+++ b/cmd/txt-suite/main.go
@@ -66,6 +66,10 @@ func main() {
 		testnos, _ = deconstructFlag()
 	}
 
+	if *tpmdev != "" {
+		test.TpmPath = *tpmdev
+	}
+
 	if !*help && !*listtests && !*version {
 		ret = run()
 	} else {

--- a/pkg/test/tpm.go
+++ b/pkg/test/tpm.go
@@ -19,6 +19,7 @@ const (
 var (
 	tpm12Connection   *io.ReadWriteCloser = nil
 	tpm20Connection   *io.ReadWriteCloser = nil
+	TpmPath           string              = "/dev/tpm0"
 	testtpmconnection                     = Test{
 		Name:     "TPM connection",
 		Required: true,
@@ -67,11 +68,10 @@ var (
 
 // Connects to a TPM device (virtual or real) at the given path
 func TestTPMConnect() (bool, error) {
-	tpmPath := "/dev/tpm0"
-	conn, err := tpm2.OpenTPM(tpmPath)
+	conn, err := tpm2.OpenTPM(TpmPath)
 
 	if err != nil {
-		conn, err = tpm1.OpenTPM(tpmPath)
+		conn, err = tpm1.OpenTPM(TpmPath)
 
 		if err != nil {
 			return false, fmt.Errorf("Cannot connect to TPM: %s\n", err)


### PR DESCRIPTION
Add -tpm argument for passing a specific tpm-device to the test suite
Fixes issue35