### PR TITLE
Split TPMPresent tests into three seperate tests.

### DIFF
--- a/pkg/test/tpm.go
+++ b/pkg/test/tpm.go
@@ -126,7 +126,7 @@ func TestTPM2Present() (bool, error) {
 }
 
 func TestTPMIsPresent() (bool, error) {
-	if (tpm12Connection != nil) || (tpm20Connection != nil) {
+	if (testtpm12present.Result.String() == "Pass") || (testtpm2present.Result.String() == "Pass") {
 		return true, nil
 	}
 	return false, fmt.Errorf("No TPM present")

--- a/pkg/test/tpm.go
+++ b/pkg/test/tpm.go
@@ -126,7 +126,7 @@ func TestTPM2Present() (bool, error) {
 }
 
 func TestTPMIsPresent() (bool, error) {
-	if (testtpm12present.Result.String() == "Pass") || (testtpm2present.Result.String() == "Pass") {
+	if (testtpm12present.Result.String() == "PASS") || (testtpm2present.Result.String() == "PASS") {
 		return true, nil
 	}
 	return false, fmt.Errorf("No TPM present")

--- a/pkg/test/tpm.go
+++ b/pkg/test/tpm.go
@@ -126,7 +126,7 @@ func TestTPM2Present() (bool, error) {
 }
 
 func TestTPMIsPresent() (bool, error) {
-	if (testtpm12present.Result.String() == "PASS") || (testtpm2present.Result.String() == "PASS") {
+	if (testtpm12present.Result == ResultPass) || (testtpm2present.Result == ResultPass) {
 		return true, nil
 	}
 	return false, fmt.Errorf("No TPM present")


### PR DESCRIPTION
Made TestTPM12Present and TestTPM2Present optional
Third Test is required and checks that at least one connection is available