### PR TITLE
Split ParseACM in ParseACMHeader, ValidateACMHeader, ParseACM

### DIFF
--- a/pkg/api/acm.go
+++ b/pkg/api/acm.go
@@ -176,12 +176,21 @@ func ParseACM(data []byte) (*ACM, *Chipsets, *Processors, *TPMs, error) {
 	}
 
 	//Generate byte slice for scratch with scratchSize from acm header
-	scratch := make([]byte, acmheader.ScratchSize)
+	scratch := make([]byte, acmheader.ScratchSize*4)
 	//Build up struct with correct size
 	acm := ACM{ACMHeader{}, scratch, ACMInfo{}}
 
 	buf.Seek(int64(0), io.SeekStart)
-	err = binary.Read(buf, binary.LittleEndian, &acm)
+	err = binary.Read(buf, binary.LittleEndian, &acm.Header)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	err = binary.Read(buf, binary.LittleEndian, &acm.Scratch)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	err = binary.Read(buf, binary.LittleEndian, &acm.Info)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/pkg/api/acm.go
+++ b/pkg/api/acm.go
@@ -39,6 +39,7 @@ const (
 )
 
 const vendorIntel = 0x00008086
+const ACMheaderLen = uint32(161)
 
 type UUID struct {
 	Field1 uint32
@@ -148,7 +149,7 @@ func ValidateACMHeader(acmheader *ACMHeader) (bool, error) {
 	if acmheader.ModuleSubType >= uint16(2) {
 		return false, fmt.Errorf("BIOS ACM ModuleSubType is greater 1, this is not specified - Intel TXT Software Development Guide, Document: 315168-013, P. 84")
 	}
-	if acmheader.HeaderLen < uint32(4*161) {
+	if acmheader.HeaderLen < uint32(ACMheaderLen) {
 		return false, fmt.Errorf("BIOS ACM HeaderLength is smaller than 4*161 Byte - Intel TXT Software Development Guide, Document: 315168-013, P. 83")
 	}
 	if acmheader.Size == 0 {

--- a/pkg/api/acm.go
+++ b/pkg/api/acm.go
@@ -38,6 +38,8 @@ const (
 	TPMAlgoSM2               uint16 = 0x001B
 )
 
+const vendorIntel = 0x00008086
+
 type UUID struct {
 	Field1 uint32
 	Field2 uint16
@@ -93,7 +95,7 @@ type TPMs struct {
 	AlgID        []uint16
 }
 
-type ACM struct {
+type ACMHeader struct {
 	ModuleType      uint16
 	ModuleSubType   uint16
 	HeaderLen       uint32
@@ -117,14 +119,17 @@ type ACM struct {
 	PubKey          [256]uint8
 	PubExp          uint32
 	Signatur        [256]uint8
-	Scratch         [143]uint32
-	Info            ACMInfo
+}
+type ACM struct {
+	Header  ACMHeader
+	Scratch [143]uint32
+	Info    ACMInfo
 }
 
 // ParseACMHeader
 
-func ParseACMHeader(data []byte) (*ACM, error) {
-	var acm ACM
+func ParseACMHeader(data []byte) (*ACMHeader, error) {
+	var acm ACMHeader
 	buf := bytes.NewReader(data)
 	err := binary.Read(buf, binary.LittleEndian, &acm)
 
@@ -136,18 +141,21 @@ func ParseACMHeader(data []byte) (*ACM, error) {
 }
 
 // ValidateACMHeader
-func ValidateACMHeader(acm *ACM) (bool, error) {
-	if acm.ModuleType != uint16(2) {
+func ValidateACMHeader(acmheader *ACMHeader) (bool, error) {
+	if acmheader.ModuleType != uint16(2) {
 		return false, fmt.Errorf("BIOS ACM ModuleType is not 2, this is not specified - Intel TXT Software Development Guide, Document: 315168-013, P. 84")
 	}
-	if acm.ModuleSubType >= uint16(2) {
+	if acmheader.ModuleSubType >= uint16(2) {
 		return false, fmt.Errorf("BIOS ACM ModuleSubType is greater 1, this is not specified - Intel TXT Software Development Guide, Document: 315168-013, P. 84")
 	}
-	if acm.HeaderLen < uint32(4*161) {
+	if acmheader.HeaderLen < uint32(4*161) {
 		return false, fmt.Errorf("BIOS ACM HeaderLength is smaller than 4*161 Byte - Intel TXT Software Development Guide, Document: 315168-013, P. 83")
 	}
-	if acm.Size == 0 {
+	if acmheader.Size == 0 {
 		return false, fmt.Errorf("BIOS ACM Size can't be zero!")
+	}
+	if acmheader.ModuleVendor != vendorIntel {
+		return false, fmt.Errorf("AC Module Vendor is not Intel. Only Intel as Vendor is allowed")
 	}
 	return true, nil
 }
@@ -227,37 +235,37 @@ func LookupSize(header []byte) (int64, error) {
 func (a *ACM) PrettyPrint() {
 	log.Println("Authenticated Code Module")
 
-	if a.ModuleVendor == ACMVendorIntel {
+	if a.Header.ModuleVendor == ACMVendorIntel {
 		log.Println("Module Vendor: Intel")
 	} else {
 		log.Println("Module Vendor: Unknown")
 	}
 
-	if a.ModuleType == ACMTypeChipset {
+	if a.Header.ModuleType == ACMTypeChipset {
 		log.Println("Module Type: ACM_TYPE_CHIPSET")
 	} else {
 		log.Println("Module Type: UNKNOWN")
 	}
 
-	if a.ModuleSubType == ACMSubTypeReset {
+	if a.Header.ModuleSubType == ACMSubTypeReset {
 		log.Println("Module Subtype: Execute at Reset")
-	} else if a.ModuleSubType == 0 {
+	} else if a.Header.ModuleSubType == 0 {
 		log.Println("Module Subtype: 0x0")
 	} else {
 		log.Println("Module Subtype: Unknown")
 	}
-	log.Printf("Module Date: 0x%02x\n", a.Date)
-	log.Printf("Module Size: %db\n", a.Size*4)
+	log.Printf("Module Date: 0x%02x\n", a.Header.Date)
+	log.Printf("Module Size: %db\n", a.Header.Size*4)
 
-	log.Printf("Header Length: %db\n", a.HeaderLen)
-	log.Printf("Header Version: %d\n", a.HeaderVersion)
-	log.Printf("Chipset ID: 0x%02x\n", a.ChipsetID)
-	log.Printf("Flags: 0x%02x\n", a.Flags)
-	log.Printf("TXT SVN: 0x%08x\n", a.TxtSVN)
-	log.Printf("SE SVN: 0x%08x\n", a.SeSVN)
-	log.Printf("Code Control: 0x%02x\n", a.CodeControl)
-	log.Printf("Entry Point: 0x%08x:%08x\n", a.SegSel, a.EntryPoint)
-	log.Printf("Scratch Size: %db\n", a.ScratchSize)
+	log.Printf("Header Length: %db\n", a.Header.HeaderLen)
+	log.Printf("Header Version: %d\n", a.Header.HeaderVersion)
+	log.Printf("Chipset ID: 0x%02x\n", a.Header.ChipsetID)
+	log.Printf("Flags: 0x%02x\n", a.Header.Flags)
+	log.Printf("TXT SVN: 0x%08x\n", a.Header.TxtSVN)
+	log.Printf("SE SVN: 0x%08x\n", a.Header.SeSVN)
+	log.Printf("Code Control: 0x%02x\n", a.Header.CodeControl)
+	log.Printf("Entry Point: 0x%08x:%08x\n", a.Header.SegSel, a.Header.EntryPoint)
+	log.Printf("Scratch Size: %db\n", a.Header.ScratchSize)
 	log.Println("Info Table:")
 
 	uuidStr := fmt.Sprintf("%08x-%04x-%04x-%04x-%02x%02x%02x%02x%02x%02x",

--- a/pkg/api/acm.go
+++ b/pkg/api/acm.go
@@ -121,6 +121,37 @@ type ACM struct {
 	Info            ACMInfo
 }
 
+// ParseACMHeader
+
+func ParseACMHeader(data []byte) (*ACM, error) {
+	var acm ACM
+	buf := bytes.NewReader(data)
+	err := binary.Read(buf, binary.LittleEndian, &acm)
+
+	if err != nil {
+		return nil, fmt.Errorf("Can't read ACM Header")
+	}
+
+	return &acm, nil
+}
+
+// ValidateACMHeader
+func ValidateACMHeader(acm *ACM) (bool, error) {
+	if acm.ModuleType != uint16(2) {
+		return false, fmt.Errorf("BIOS ACM ModuleType is not 2, this is not specified - Intel TXT Software Development Guide, Document: 315168-013, P. 84")
+	}
+	if acm.ModuleSubType >= uint16(2) {
+		return false, fmt.Errorf("BIOS ACM ModuleSubType is greater 1, this is not specified - Intel TXT Software Development Guide, Document: 315168-013, P. 84")
+	}
+	if acm.HeaderLen < uint32(4*161) {
+		return false, fmt.Errorf("BIOS ACM HeaderLength is smaller than 4*161 Byte - Intel TXT Software Development Guide, Document: 315168-013, P. 83")
+	}
+	if acm.Size == 0 {
+		return false, fmt.Errorf("BIOS ACM Size can't be zero!")
+	}
+	return true, nil
+}
+
 // ParseACM
 func ParseACM(data []byte) (*ACM, *Chipsets, *Processors, *TPMs, error) {
 	var acm ACM

--- a/pkg/api/acm.go
+++ b/pkg/api/acm.go
@@ -164,36 +164,29 @@ func ValidateACMHeader(acmheader *ACMHeader) (bool, error) {
 // ParseACM
 func ParseACM(data []byte) (*ACM, *Chipsets, *Processors, *TPMs, error) {
 	var acmheader ACMHeader
+	var acminfo ACMInfo
 	var processors Processors
 	var chipsets Chipsets
 	var tpms TPMs
 
-	//Read only ACM Header without scratch to get scratchSize
 	buf := bytes.NewReader(data)
 	err := binary.Read(buf, binary.LittleEndian, &acmheader)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
-
-	//Generate byte slice for scratch with scratchSize from acm header
 	scratch := make([]byte, acmheader.ScratchSize*4)
-	//Build up struct with correct size
-	acm := ACM{ACMHeader{}, scratch, ACMInfo{}}
 
-	buf.Seek(int64(0), io.SeekStart)
-	err = binary.Read(buf, binary.LittleEndian, &acm.Header)
-	if err != nil {
-		return nil, nil, nil, nil, err
-	}
-	err = binary.Read(buf, binary.LittleEndian, &acm.Scratch)
+	err = binary.Read(buf, binary.LittleEndian, &scratch)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
 
-	err = binary.Read(buf, binary.LittleEndian, &acm.Info)
+	err = binary.Read(buf, binary.LittleEndian, &acminfo)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
+
+	acm := ACM{acmheader, scratch, acminfo}
 
 	buf.Seek(int64(acm.Info.ChipsetIDList), io.SeekStart)
 	err = binary.Read(buf, binary.LittleEndian, &chipsets.Count)

--- a/pkg/test/fit.go
+++ b/pkg/test/fit.go
@@ -16,7 +16,6 @@ const FITVector = 0xFFFFFFC0
 const ACMheaderLegSize = uint32(4 * 161)
 const ValidFitRange = 0xFF000000
 
-
 var (
 	fitImage []byte
 	// set by FITVectorIsSet
@@ -405,7 +404,7 @@ func TestBIOSACMSizeCorrect() (bool, error) {
 		return false, err
 	}
 
-	if acm.HeaderLen%64 != 0 {
+	if acm.Header.HeaderLen%64 != 0 {
 		return false, fmt.Errorf("BIOSACM Size is not correct ")
 	}
 	return true, nil

--- a/pkg/test/fit.go
+++ b/pkg/test/fit.go
@@ -13,7 +13,6 @@ const FITSize int64 = 16 * 1024 * 1024
 const FourGiB int64 = 0x100000000
 const ResetVector = 0xFFFFFFF0
 const FITVector = 0xFFFFFFC0
-const ACMheaderLegSize = uint32(4 * 161)
 const ValidFitRange = 0xFF000000
 
 var (
@@ -404,7 +403,7 @@ func TestBIOSACMSizeCorrect() (bool, error) {
 		return false, err
 	}
 
-	if acm.Header.HeaderLen%64 != 0 {
+	if acm.Header.HeaderLen%32 != 0 {
 		return false, fmt.Errorf("BIOSACM Size is not correct ")
 	}
 	return true, nil
@@ -484,7 +483,7 @@ func TestBIOSACMMatchesCPU() (bool, error) {
 func biosACM(fit []api.FitEntry) (*api.ACM, *api.Chipsets, *api.Processors, *api.TPMs, error) {
 	for _, ent := range fit {
 		if ent.Type() == api.StartUpACMod {
-			buf1 := make([]byte, ACMheaderLegSize)
+			buf1 := make([]byte, api.ACMheaderLen*4)
 
 			err := api.ReadPhysBuf(int64(ent.Address), buf1)
 
@@ -503,7 +502,7 @@ func biosACM(fit []api.FitEntry) (*api.ACM, *api.Chipsets, *api.Processors, *api
 				return nil, nil, nil, nil, fmt.Errorf("Validating BIOS ACM Header failed: %v", err)
 			}
 
-			buf2 := make([]byte, acm.Size)
+			buf2 := make([]byte, acm.Size*4)
 			err = api.ReadPhysBuf(int64(ent.Address), buf2)
 
 			if err != nil {

--- a/pkg/test/fit.go
+++ b/pkg/test/fit.go
@@ -13,6 +13,7 @@ const FITSize int64 = 16 * 1024 * 1024
 const FourGiB int64 = 0x100000000
 const ResetVector = 0xFFFFFFF0
 const FITVector = 0xFFFFFFC0
+const ACMheaderLegSize = uint32(4 * 161)
 
 var (
 	fitImage []byte
@@ -391,7 +392,7 @@ func TestBIOSACMSizeCorrect() (bool, error) {
 		return false, err
 	}
 
-	return acm.HeaderLen%64 == 0, nil
+	return acm.Header.HeaderLen%64 == 0, nil
 }
 
 func TestBIOSACMAlignmentCorrect() (bool, error) {
@@ -423,7 +424,7 @@ func TestBIOSACMMatchesChipset() (bool, error) {
 		b := ch.DeviceID == txt.Did
 
 		if a && b {
-			if acm.Flags&1 != 0 {
+			if acm.Header.Flags&1 != 0 {
 				if ch.RevisionID&txt.Rid == txt.Rid {
 					return true, nil
 				}
@@ -467,7 +468,7 @@ func TestBIOSACMMatchesCPU() (bool, error) {
 func biosACM(fit []api.FitEntry) (*api.ACM, *api.Chipsets, *api.Processors, *api.TPMs, error) {
 	for _, ent := range fit {
 		if ent.Type() == api.StartUpACMod {
-			buf1 := make([]byte, 224*4)
+			buf1 := make([]byte, ACMheaderLegSize)
 
 			err := api.ReadPhysBuf(int64(ent.Address), buf1)
 

--- a/pkg/test/fit.go
+++ b/pkg/test/fit.go
@@ -403,7 +403,7 @@ func TestBIOSACMSizeCorrect() (bool, error) {
 		return false, err
 	}
 
-	if acm.Header.HeaderLen%32 != 0 {
+	if (acm.Header.HeaderLen*4)%4 == 0 {
 		return false, fmt.Errorf("BIOSACM Size is not correct ")
 	}
 	return true, nil

--- a/pkg/test/fit.go
+++ b/pkg/test/fit.go
@@ -403,7 +403,7 @@ func TestBIOSACMSizeCorrect() (bool, error) {
 		return false, err
 	}
 
-	if (acm.Header.HeaderLen*4)%4 == 0 {
+	if (acm.Header.HeaderLen*4)%4 != 0 {
 
 		return false, fmt.Errorf("BIOSACM Size is not correct ")
 	}

--- a/pkg/test/memory.go
+++ b/pkg/test/memory.go
@@ -362,7 +362,7 @@ func TestSINITInTXT() (bool, error) {
 		return false, err
 	}
 
-	return acm.ModuleType == 2, nil
+	return acm.Header.ModuleType == 2, nil
 }
 
 func TestSINITMatchesChipset() (bool, error) {
@@ -385,7 +385,7 @@ func TestSINITMatchesChipset() (bool, error) {
 		b := ch.DeviceID == regs.Did
 
 		if a && b {
-			if acm.Flags&1 != 0 {
+			if acm.Header.Flags&1 != 0 {
 				if ch.RevisionID&regs.Rid == regs.Rid {
 					return true, nil
 				}

--- a/pkg/test/tpm.go
+++ b/pkg/test/tpm.go
@@ -26,10 +26,24 @@ var (
 		function: TestTPMConnect,
 		Status:   TestImplemented,
 	}
-	testtpmispresent = Test{
+	testtpm12present = Test{
 		Name:         "TPM 1.2 present",
+		Required:     false,
+		function:     TestTPM12Present,
+		dependencies: []*Test{&testtpmconnection},
+		Status:       TestImplemented,
+	}
+	testtpm2present = Test{
+		Name:         "TPM 2 is present",
+		Required:     false,
+		function:     TestTPM2Present,
+		dependencies: []*Test{&testtpmconnection},
+		Status:       TestImplemented,
+	}
+	testtpmispresent = Test{
+		Name:         "TPM is present",
 		Required:     true,
-		function:     TestTPMPresent,
+		function:     TestTPMIsPresent,
 		dependencies: []*Test{&testtpmconnection},
 		Status:       TestImplemented,
 	}
@@ -64,6 +78,8 @@ var (
 
 	TestsTPM = [...]*Test{
 		&testtpmconnection,
+		&testtpm12present,
+		&testtpm2present,
 		&testtpmispresent,
 		&testtpmislocked,
 		&testpsindexisset,
@@ -91,19 +107,29 @@ func TestTPMConnect() (bool, error) {
 	return true, nil
 }
 
-// Checks whether a TPM is present and answers to GetCapability
-func TestTPMPresent() (bool, error) {
-	if tpm12Connection != nil {
-		vid, err := tpm1.GetManufacturer(*tpm12Connection)
-
-		return vid != nil && err == nil, nil
-	} else if tpm20Connection != nil {
-		ca, _, err := tpm2.GetCapability(*tpm20Connection, tpm2.CapabilityTPMProperties, 1, uint32(tpm2.Manufacturer))
-
-		return ca != nil && err == nil, nil
-	} else {
-		return false, fmt.Errorf("No TPM connection")
+// Checks if TPM 1.2 is present and answers to GetCapability
+func TestTPM12Present() (bool, error) {
+	if tpm12Connection == nil {
+		return false, fmt.Errorf("No TPM 1.2 connection")
 	}
+	vid, err := tpm1.GetManufacturer(*tpm12Connection)
+	return vid != nil && err == nil, nil
+
+}
+
+func TestTPM2Present() (bool, error) {
+	if tpm20Connection == nil {
+		return false, fmt.Errorf("No TPM 2 connection")
+	}
+	ca, _, err := tpm2.GetCapability(*tpm20Connection, tpm2.CapabilityTPMProperties, 1, uint32(tpm2.Manufacturer))
+	return ca != nil && err == nil, nil
+}
+
+func TestTPMIsPresent() (bool, error) {
+	if (testtpm12present.Result == ResultPass) || (testtpm2present.Result == ResultPass) {
+		return true, nil
+	}
+	return false, fmt.Errorf("No TPM present")
 }
 
 // TPM NVRAM is locked


### PR DESCRIPTION
biosACM now reads BIOS ACM Header, returns object, validates header,
reads again whole acm based on size inside acm header and parses it