### PR TITLE
Fixing ACMParser again

### DIFF
--- a/pkg/api/acm.go
+++ b/pkg/api/acm.go
@@ -69,8 +69,7 @@ type ChipsetID struct {
 	VendorID   uint16
 	DeviceID   uint16
 	RevisionID uint16
-	Reserved   uint16
-	ExtendedID uint16
+	Reserved   [3]uint16
 }
 
 type Chipsets struct {
@@ -334,7 +333,6 @@ func (c *Chipsets) PrettyPrint() {
 		log.Printf("\t\tVendor: 0x%02x\n", chipset.VendorID)
 		log.Printf("\t\tDevice: 0x%02x\n", chipset.DeviceID)
 		log.Printf("\t\tRevision: 0x%02x\n", chipset.RevisionID)
-		log.Printf("\t\tExtended: 0x%02x\n", chipset.ExtendedID)
 	}
 }
 

--- a/pkg/test/fit.go
+++ b/pkg/test/fit.go
@@ -422,7 +422,7 @@ func TestBIOSACMAlignmentCorrect() (bool, error) {
 }
 
 func TestBIOSACMMatchesChipset() (bool, error) {
-	acm, chp, _, _, err := biosACM(fit)
+	_, chp, _, _, err := biosACM(fit)
 	if err != nil {
 		return false, err
 	}
@@ -440,8 +440,8 @@ func TestBIOSACMMatchesChipset() (bool, error) {
 		b := ch.DeviceID == txt.Did
 
 		if a && b {
-			if acm.Header.Flags&1 != 0 {
-				if ch.RevisionID&txt.Rid == txt.Rid {
+			if ch.Flags&1 != 0 {
+				if ch.RevisionID&txt.Rid > 0 {
 					return true, nil
 				}
 			} else {


### PR DESCRIPTION
Fixed ChipsetID struct for correct alignments
Fixed TestBIOSACMMatchesChipset