### PR TITLE
API: Accept upper case "reserved" keyword

### DIFF
--- a/pkg/api/e820.go
+++ b/pkg/api/e820.go
@@ -5,9 +5,19 @@ import (
 	"io/ioutil"
 	"os"
 	"strconv"
+	"strings"
 )
 
-const reservedKeyword = "Reserved\n"
+func isReservedType(regionType string) bool {
+	switch t := strings.TrimSpace(regionType); t {
+	case "reserved":
+		return true
+	case "Reserved":
+		return true
+	default:
+		return false
+	}
+}
 
 // Reads the e820 table exported via /sys/firmware/memmap and checks whether
 // the range [start; end] is marked as reserved. Returns true if it is reserved,
@@ -36,7 +46,7 @@ func IsReservedInE810(start uint64, end uint64) (bool, error) {
 				continue
 			}
 
-			if string(buf) == reservedKeyword {
+			if isReservedType(string(buf)) {
 				path := fmt.Sprintf("/sys/firmware/memmap/%s/start", subdir.Name())
 				this_start, err := readHexInteger(path)
 				if err != nil {


### PR DESCRIPTION
Depending on the kernel version, it might be uppercase or lowercase. 

See https://github.com/torvalds/linux/commit/640e1b38b00550990cecd809021cd37716e45922.