### PR TITLE
pkg/test: Make pkg usable for external use

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@ Intel TXT Validation Test Suite
 ===============================
 
 This Golang utility tests whether the platform supports Intel TXT and FIT, TPM
-boot chain has been configured correctly.
+boot chain has been configured correctly under x86_64 linux.
+The only supported architecture is x86_64.
 
 The suite is work in progress.
 
@@ -77,6 +78,7 @@ Run it as root:
 
 Commandline arguments
 ```bash
+-m : Generate markdown
 -l : Lists all tests
 -log : Specify a path/filename.json where test results will be written (only in combination with test enforcing (-i option))
 -i : interactive move - Test will stop if an error occurs. Test results will be written to test_log.json
@@ -84,6 +86,66 @@ Commandline arguments
 -t=<n-m> or -t=<n-m,o-p> : Choose ranges of tests, can be seperated by comma
 -v : Gives information about Licence, Copyright and Version
 -h : Shows this information
+-txtready   : Test if platform is TXTReady
+-legacyboot : Test if platform is TXT Legacy boot enabled
+```
+
+API Usage
+---------
+
+**To test for TXTReady**:
+
+```
+package main
+
+import (
+	"log"
+
+	"github.com/9elements/txt-suite/pkg/hwapi"
+	"github.com/9elements/txt-suite/pkg/test"
+)
+
+func main() {
+	hwAPI := hwapi.GetApi()
+
+	success, failureMsg, err := test.RunTestsSilent(hwAPI, test.TestsTXTReady)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if !success {
+		log.Printf("Platform not TXTReady as of: '%s'\n", failureMsg)
+	} else {
+		log.Printf("Platform is TXTReady!\n")
+	}
+}
+```
+
+
+**To test for TXT legacy boot (Initial Bootblock measured before PoR)**:
+
+```
+package main
+
+import (
+	"log"
+
+	"github.com/9elements/txt-suite/pkg/hwapi"
+	"github.com/9elements/txt-suite/pkg/test"
+)
+
+func main() {
+	hwAPI := hwapi.GetApi()
+
+	success, failureMsg, err := test.RunTestsSilent(hwAPI, test.TestsTXTLegacyBoot)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if !success {
+		log.Printf("Platform not TXTReady as of: '%s'\n", failureMsg)
+	} else {
+		log.Printf("Platform is TXTReady!\n")
+	}
+}
 ```
 
 Tests

--- a/cmd/txt-suite/cmd.go
+++ b/cmd/txt-suite/cmd.go
@@ -18,6 +18,8 @@ var teststomarkdown = flag.Bool("m", false, "Output test implementation state as
 var version = flag.Bool("v", false, "Shows Version, copyright info and license")
 var tpmdev = flag.String("tpm", "", "Select TPM-Path. e.g.: -tpm=/dev/tpmX, with X as number of the TPM module")
 var logpath = flag.String("log", "", "Give a path/filename for test result output in JSON format. e.g.: /path/to/filename.json")
+var txtready = flag.Bool("txtready", false, "Test if platform is TXTReady")
+var legacyboot = flag.Bool("legacyboot", false, "Test if platform is TXT Legacy boot enabled")
 
 func flagUsed() bool {
 	return testno != nil
@@ -38,11 +40,13 @@ func showHelp() {
 	fmt.Println("Usage: txt-suite [-l] [-h] [-v] [-i] [-t TESTSPEC]")
 	fmt.Println("")
 	fmt.Println("\t-t TESTSPEC : Only run a subset of tests. TESTSPEC is a comma-separated list of integers or ranges (n-m).")
-	fmt.Println("\t-i : Ignore failing tests. Results are written to test_log.json")
-	fmt.Println("\t-h : Shows this help")
-	fmt.Println("\t-m : Generate markdown")
-	fmt.Println("\t-l : Lists all tests with their test number.")
-	fmt.Println("\t-v : Shows version, license and copyright.")
+	fmt.Println("\t-i          : Ignore failing tests. Results are written to test_log.json")
+	fmt.Println("\t-h          : Shows this help")
+	fmt.Println("\t-m          : Generate markdown")
+	fmt.Println("\t-l          : Lists all tests with their test number.")
+	fmt.Println("\t-v          : Shows version, license and copyright.")
+	fmt.Println("\t-txtready   : Test if platform is TXTReady")
+	fmt.Println("\t-legacyboot : Test if platform is TXT Legacy boot enabled")
 }
 
 func getTests() []*test.Test {

--- a/cmd/txt-suite/main.go
+++ b/cmd/txt-suite/main.go
@@ -28,14 +28,11 @@ type temptest struct {
 	Status     string
 }
 
-func run() bool {
+func run(tests []*test.Test) bool {
 	var result = false
-	var tests []*test.Test
 	f := bufio.NewWriter(os.Stdout)
 
 	hwAPI := hwapi.GetApi()
-
-	tests = getTests()
 
 	for idx := range tests {
 		if len(testnos) > 0 {
@@ -116,8 +113,12 @@ func main() {
 		showVersion()
 	} else if *teststomarkdown == true {
 		listTestsAsMarkdown()
+	} else if *txtready == true {
+		ret = run(test.TestsTXTReady)
+	} else if *legacyboot == true {
+		ret = run(test.TestsTXTLegacyBoot)
 	} else {
-		ret = run()
+		ret = run(getTests())
 	}
 
 	if ret {


### PR DESCRIPTION
Add an API to easily integrate the test suite into existing applications.
The application must then be run with highest possible priviledges on an
Intel x86_64 platform.

Signed-off-by: Patrick Rudolph <patrick.rudolph@9elements.com>