### PR TITLE
hwapi: Replace CGO with assembly code

### DIFF
--- a/pkg/hwapi/cpuid_amd64.go
+++ b/pkg/hwapi/cpuid_amd64.go
@@ -1,23 +1,11 @@
+// +build amd64
+
+// Package hwapi provides access to low level hardware
 package hwapi
 
-// #include <stdint.h>
-//
-// uint32_t cpuid_leaf1_eax(void) {
-//   uint32_t ret = 0;
-//
-//   asm volatile(
-//     "movl $1, %%eax\n"
-//     "movl $0, %%ecx\n"
-//     "cpuid\n"
-//     "movl %%eax, %0\n"
-//     : "=m"(ret)
-//     :
-//     : "eax", "ebx", "ecx", "edx");
-//
-//   return ret;
-// }
-import "C"
 import "github.com/intel-go/cpuid"
+
+func cpuidLow(arg1, arg2 uint32) (eax, ebx, ecx, edx uint32) // implemented in cpuidlow_amd64.s
 
 //VersionString returns the vendor ID
 func (t TxtAPI) VersionString() string {
@@ -46,7 +34,8 @@ func (t TxtAPI) ProcessorBrandName() string {
 
 //CPUSignature returns CPUID=1 eax
 func (t TxtAPI) CPUSignature() uint32 {
-	return uint32(C.cpuid_leaf1_eax())
+	eax, _, _, _ := cpuidLow(1, 0)
+	return eax
 }
 
 //CPULogCount returns number of logical CPU cores

--- a/pkg/hwapi/cpuidlow_amd64.s
+++ b/pkg/hwapi/cpuidlow_amd64.s
@@ -1,0 +1,15 @@
+// Copyright 2017 Intel Corporation.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+#include "textflag.h"
+
+// func cpuidLow(arg1, arg2 uint32) (eax, ebx, ecx, edx uint32)
+TEXT ·cpuidLow(SB),NOSPLIT,$0-24
+    MOVL    arg1+0(FP), AX
+    MOVL    arg2+4(FP), CX
+    CPUID
+    MOVL AX, eax+8(FP)
+    MOVL BX, ebx+12(FP)
+    MOVL CX, ecx+16(FP)
+    MOVL DX, edx+20(FP)
+    RET


### PR DESCRIPTION
As this suite will run on x86_64 any way, only add cpuid assembly for this
architecture.

Signed-off-by: Patrick Rudolph <patrick.rudolph@9elements.com>